### PR TITLE
screenWidthDp crash on pre SDK 13 devices

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=Google Inc.:Google APIs:17
+target=android-17


### PR DESCRIPTION
Only reference Configuration.screenWidthDp / smallestScreenWidthDp on SDK 13 and above devices. Currently crashing on pre 13 devices ..
